### PR TITLE
Added a new event emitter to Client

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 This changelog uses [Semantic Versioning 2.0.0](https://semver.org/).
-
+## `6.15.4`
+### Changes:
+ + Added `'ready'` emitter for client when it will be able to successfully preform PacketIO actions.
 ## `6.15.3`
 ### Fixes:
  + Added error handling for `packet.read()` calls in the `PacketIO`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrelay",
-  "version": "6.15.3",
+  "version": "6.15.4",
   "description": "A console based modular client for Realm of the Mad God built with Node.js and TypeScript.",
   "main": "index.js",
   "bin": {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -505,6 +505,7 @@ export class Client {
         this.objectId = createSuccessPacket.objectId;
         this.charInfo.charId = createSuccessPacket.charId;
         this.charInfo.nextCharId = this.charInfo.charId + 1;
+        Client.emitter.emit('ready', Object.assign({}, this.playerData), this);
         Log(this.alias, 'Connected!', LogLevel.Success);
     }
 


### PR DESCRIPTION
You are able to preform things like sending trade request packet or moving when the client successfully creates it's object. Did not work with 'connect' because that is when the client receives map info, sending packets will cause the client to disconnect.