### PR TITLE
Fix for issue #47.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 This changelog uses [Semantic Versioning 2.0.0](https://semver.org/).
 
+## `8.8.6`
+### Fixed:
+  + Fixed a bug where the resource manager would overwrite object data with stripped versions that appear later in Objects.json.
+  + Replaced `FeedPower` with `feedPower` to match Objects.json.
+
 ## `8.8.0`
 ### Added:
  + The client token is now configurable via the `versions.json` file. This token will be appended to the end of the hello packet when connection attempts are made.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrelay",
-  "version": "8.8.5",
+  "version": "8.8.6",
   "description": "A console based modular client for Realm of the Mad God built with Node.js and TypeScript.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/core/resource-manager.ts
+++ b/src/core/resource-manager.ts
@@ -93,7 +93,7 @@ export class ResourceManager {
           numProjectiles: isNaN(current.NumProjectiles) ? 1 : +current.NumProjectiles,
           arcGap: isNaN(current.ArcGap) ? 11.25 : +current.ArcGap,
           fameBonus: isNaN(current.FameBonus) ? 0 : +current.FameBonus,
-          feedPower: isNaN(current.FeedPower) ? 0 : +current.FeedPower,
+          feedPower: isNaN(current.feedPower) ? 0 : +current.feedPower,
           fullOccupy: current.FullOccupy === '',
           occupySquare: current.OccupySquare === '',
           protectFromGroundDamage: current.ProtectFromGroundDamage === '',

--- a/src/core/resource-manager.ts
+++ b/src/core/resource-manager.ts
@@ -69,6 +69,9 @@ export class ResourceManager {
     let petCount = 0;
     let objectsArray: any[] = objects.Object;
     for (const current of objectsArray) {
+      if (this.objects[+current.type] != null) {
+        continue;
+      }
       try {
         this.objects[+current.type] = {
           type: +current.type,


### PR DESCRIPTION
This pull request fixes issue #47 and one more bug regarding feed power.
It consists of:
  + an if statement that stops the `ResourceManager` from replacing genuine object data with stripped data that appears later in the Objects.json document.
  + changing FeedPower to feedPower in the `ResourceManager` as to correctly reflect the Objects.json document.

Please note that I have not tested this thoroughly so I urge you to see if there are any obvious problems and do not hesitate to correct me in any way.

Thanks, iremnant.

![image](https://user-images.githubusercontent.com/64452551/80843305-79808100-8bf3-11ea-984c-b878b0db2ac7.png)

